### PR TITLE
Email Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EmailCommand.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.student.Student;
+
+public class EmailCommand extends Command {
+    public static final String COMMAND_WORD = "emails";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        StringBuilder concatenatedEmails = new StringBuilder();
+        requireNonNull(model);
+        List<Student> studentList = model.getFilteredStudentList();
+
+        for (Student stu : studentList) {
+            concatenatedEmails.append(stu.getEmail()).append(";");
+        }
+
+        return new CommandResult(concatenatedEmails.toString());
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EmailCommand.java
@@ -19,8 +19,8 @@ public class EmailCommand extends Command {
         StringBuilder concatenatedEmails = new StringBuilder();
         List<Student> studentList = model.getFilteredStudentList();
 
-        for (Student stu : studentList) {
-            concatenatedEmails.append(stu.getEmail()).append(";");
+        for (Student student : studentList) {
+            concatenatedEmails.append(student.getEmail()).append(";");
         }
 
         return new CommandResult(concatenatedEmails.toString());

--- a/src/main/java/seedu/address/logic/commands/EmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EmailCommand.java
@@ -13,8 +13,8 @@ public class EmailCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        StringBuilder concatenatedEmails = new StringBuilder();
         requireNonNull(model);
+        StringBuilder concatenatedEmails = new StringBuilder();
         List<Student> studentList = model.getFilteredStudentList();
 
         for (Student stu : studentList) {

--- a/src/main/java/seedu/address/logic/commands/EmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EmailCommand.java
@@ -4,15 +4,17 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.student.Student;
 
+/**
+ * Lists all emails in the address book to the user, delimited by semi colon.
+ */
 public class EmailCommand extends Command {
     public static final String COMMAND_WORD = "emails";
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         StringBuilder concatenatedEmails = new StringBuilder();
         List<Student> studentList = model.getFilteredStudentList();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteStudentCommand;
 import seedu.address.logic.commands.EditStudentCommand;
+import seedu.address.logic.commands.EmailCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindStudentCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -61,6 +62,9 @@ public class AddressBookParser {
 
         case ListStudentCommand.COMMAND_WORD:
             return new ListStudentCommand();
+
+        case EmailCommand.COMMAND_WORD:
+            return new EmailCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.Region;
 
 /**
@@ -12,6 +14,7 @@ import javafx.scene.layout.Region;
 public class ResultDisplay extends UiPart<Region> {
 
     private static final String FXML = "ResultDisplay.fxml";
+    private String feedbackToUser;
 
     @FXML
     private TextArea resultDisplay;
@@ -21,8 +24,20 @@ public class ResultDisplay extends UiPart<Region> {
     }
 
     public void setFeedbackToUser(String feedbackToUser) {
+        this.feedbackToUser = feedbackToUser;
         requireNonNull(feedbackToUser);
         resultDisplay.setText(feedbackToUser);
+    }
+
+    /**
+     * Copies the URL to the user guide to the clipboard.
+     */
+    @FXML
+    private void copyUrl() {
+        final Clipboard clipboard = Clipboard.getSystemClipboard();
+        final ClipboardContent url = new ClipboardContent();
+        url.putString(feedbackToUser);
+        clipboard.setContent(url);
     }
 
 }

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,5 +5,5 @@
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true" onMouseClicked="#copyUrl"/>
 </StackPane>

--- a/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
@@ -16,6 +16,9 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.student.Student;
 
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EmailCommand.
+ */
 public class EmailCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 

--- a/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
@@ -21,7 +21,8 @@ public class EmailCommandTest {
 
     @Test
     public void execute_getEmails_success() throws CommandException {
-        CommandResult commandResult = new EmailCommand().execute(model);
+        EmailCommand emailCommand = new EmailCommand();
+        CommandResult commandResult = emailCommand.execute(model);
         String[] emails = commandResult.getFeedbackToUser().split(";");
 
         // first layer: check if length matches

--- a/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalStudents.getTypicalStudents;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,17 +28,19 @@ public class EmailCommandTest {
         EmailCommand emailCommand = new EmailCommand();
         CommandResult commandResult = emailCommand.execute(model);
         String[] emails = commandResult.getFeedbackToUser().split(";");
+        List<Student> typicalStudents = getTypicalStudents();
 
         // first layer: check if length matches
-        assertEquals(emails.length, getTypicalStudents().size());
+        assertEquals(emails.length, typicalStudents.size());
 
         // second layer: check if all emails are in the response
-        for (Student stu : getTypicalStudents()) {
-            assertTrue(Arrays.asList(emails).contains(stu.getEmail().toString()));
+        for (Student student : typicalStudents) {
+            assertTrue(Arrays.asList(emails).contains(student.getEmail().toString()));
         }
 
         // third layer: check final message returned to user
-        String intendedMessage = Arrays.stream(emails).reduce("", (acc, el) -> acc + el + ";");
+        String intendedMessage = Arrays.stream(emails)
+                .reduce("", (accumulatedEmails, currentEmail) -> accumulatedEmails + currentEmail + ";");
         assertCommandSuccess(new EmailCommand(), model, intendedMessage, model);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalStudents.getTypicalStudents;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.student.Student;
+
+public class EmailCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_getEmails_success() throws CommandException {
+        CommandResult commandResult = new EmailCommand().execute(model);
+        String[] emails = commandResult.getFeedbackToUser().split(";");
+
+        // first layer: check if length matches
+        assertEquals(emails.length, getTypicalStudents().size());
+
+        // second layer: check if all emails are in the response
+        for (Student stu : getTypicalStudents()) {
+            assertTrue(Arrays.asList(emails).contains(stu.getEmail().toString()));
+        }
+
+        // third layer: check final message returned to user
+        String intendedMessage = Arrays.stream(emails).reduce("", (acc, el) -> acc + el + ";");
+        assertCommandSuccess(new EmailCommand(), model, intendedMessage, model);
+    }
+}


### PR DESCRIPTION
Resolves #15 - get all emails command via `emails`

To all: 
1. Let me know if the command `emails` is suitable, i was considering `list_emails`, but seems to be too long and `emails` might be faster to type.

2. This command also incorporates the copy to clipboard feature when they click on the result textarea/textbox. It will also copy when the user clicks for other commands, not sure if it'll be disruptive to the user in the future. If so, perhaps we can change it to double click? or other kind of available actions in javaFX. Think it's okay if we don't want this "copy to clipboard" feature as well since there's the default copy alr. 

Let me know what y'all think! 📈 