### PR TITLE
Fix Email Command Bug

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,5 +11,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_NAME = "The student name provided is invalid";
     public static final String MESSAGE_INVALID_SESSION_DISPLAYED_INDEX = "The session index provided is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
+    public static final String MESSAGE_NO_STUDENT = "Students are required to execute the command!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/EmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EmailCommand.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.student.Student;
 
@@ -14,12 +16,17 @@ public class EmailCommand extends Command {
     public static final String COMMAND_WORD = "emails";
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         StringBuilder concatenatedEmails = new StringBuilder();
         List<Student> studentList = model.getFilteredStudentList();
 
+        if (studentList.size() == 0) {
+            throw new CommandException(Messages.MESSAGE_NO_STUDENT);
+        }
+
         for (Student student : studentList) {
+            assert student.getEmail() != null && !student.getEmail().value.equals("");
             concatenatedEmails.append(student.getEmail()).append(";");
         }
 

--- a/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
@@ -22,6 +23,13 @@ import seedu.address.model.student.Student;
  */
 public class EmailCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_noStudent_throwsCommandException() {
+        model.updateFilteredStudentList(p -> false);
+        EmailCommand emailCommand = new EmailCommand();;
+        assertThrows(CommandException.class, () -> emailCommand.execute(model));
+    }
 
     @Test
     public void execute_getEmails_success() throws CommandException {

--- a/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
@@ -27,7 +27,7 @@ public class EmailCommandTest {
     @Test
     public void execute_noStudent_throwsCommandException() {
         model.updateFilteredStudentList(p -> false);
-        EmailCommand emailCommand = new EmailCommand();;
+        EmailCommand emailCommand = new EmailCommand();
         assertThrows(CommandException.class, () -> emailCommand.execute(model));
     }
 


### PR DESCRIPTION
Resolve #95 - Email Command not showing error with empty students

1. Fixed bug by checking student list size
2. Added test cases for no student
3. Added minor assertions just to ensure developers don't pass in students w/o email (if created manually for whatsoever reason)