### PR TITLE
Fix Student/SessionBuilder bug

### DIFF
--- a/src/test/java/seedu/address/logic/commands/AddSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSessionCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalStudents.ALICE;
 import static seedu.address.testutil.TypicalStudents.BOB;
+import static seedu.address.testutil.TypicalStudents.HOON;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,7 @@ public class AddSessionCommandTest {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Session validSession = new SessionBuilder().build();
 
-        AddSessionCommand addSessionCommand = new AddSessionCommand(validSession, ALICE.getName());
+        AddSessionCommand addSessionCommand = new AddSessionCommand(validSession, HOON.getName());
         assertThrows(CommandException.class, () -> addSessionCommand.execute(model));
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditStudentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditStudentCommandTest.java
@@ -35,7 +35,7 @@ public class EditStudentCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() throws CommandException {
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Student editedStudent = new StudentBuilder().build();
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(editedStudent).build();
         EditStudentCommand editStudentCommand = new EditStudentCommand(INDEX_FIRST_STUDENT, descriptor);
@@ -44,8 +44,6 @@ public class EditStudentCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
-
-        System.out.println(expectedMessage);
 
         assertCommandSuccess(editStudentCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/EditStudentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditStudentCommandTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditStudentCommand.EditStudentDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -34,7 +35,7 @@ public class EditStudentCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_success() throws CommandException {
         Student editedStudent = new StudentBuilder().build();
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(editedStudent).build();
         EditStudentCommand editStudentCommand = new EditStudentCommand(INDEX_FIRST_STUDENT, descriptor);
@@ -43,6 +44,8 @@ public class EditStudentCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
+
+        System.out.println(expectedMessage);
 
         assertCommandSuccess(editStudentCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/EditStudentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditStudentCommandTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditStudentCommand.EditStudentDescriptor;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -83,7 +83,7 @@ public class StudentTest {
 
         // different sessions -> result true
         editedAlice = new StudentBuilder(ALICE)
-                .withSession(new Session(new SessionDate("2020-10-01", "10:45"),
+                .addSession(new Session(new SessionDate("2020-10-01", "10:45"),
                         new Duration("10"), new Subject("Math"), new Fee("10"))).build();
         assertTrue(ALICE.equals(editedAlice));
     }

--- a/src/test/java/seedu/address/testutil/EditStudentDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditStudentDescriptorBuilder.java
@@ -1,7 +1,10 @@
 package seedu.address.testutil;
 
+import java.util.List;
+
 import seedu.address.logic.commands.EditStudentCommand;
 import seedu.address.logic.commands.EditStudentCommand.EditStudentDescriptor;
+import seedu.address.model.session.Session;
 import seedu.address.model.student.Address;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -35,6 +38,7 @@ public class EditStudentDescriptorBuilder {
         descriptor.setStudyLevel(student.getStudyLevel());
         descriptor.setGuardianPhone(student.getGuardianPhone());
         descriptor.setRelationship(student.getRelationship());
+        descriptor.setSessions(student.getListOfSessions());
     }
 
     /**
@@ -90,6 +94,14 @@ public class EditStudentDescriptorBuilder {
      */
     public EditStudentDescriptorBuilder withRelationship(String relationship) {
         descriptor.setStudyLevel(relationship);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Sessions} of the {@code EditStudentDescriptor} that we are building.
+     */
+    public EditStudentDescriptorBuilder withSessions(List<Session> sessions) {
+        descriptor.setSessions(sessions);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/address/testutil/StudentBuilder.java
@@ -24,11 +24,6 @@ public class StudentBuilder {
     public static final String DEFAULT_STUDY_LEVEL = "Secondary 5";
     public static final String DEFAULT_GUARDIAN_PHONE = "90112344";
     public static final String DEFAULT_RELATIONSHIP = "Mother";
-    public static final List<Session> DEFAULT_SESSION = new ArrayList<Session>() {
-        {
-            add(new SessionBuilder().withSessionDate("2020-01-01", "12:00").build());
-        }
-    };
 
     private Name name;
     private Phone phone;
@@ -50,7 +45,7 @@ public class StudentBuilder {
         studyLevel = DEFAULT_STUDY_LEVEL;
         guardianPhone = new Phone(DEFAULT_GUARDIAN_PHONE);
         relationship = DEFAULT_RELATIONSHIP;
-        sessions = DEFAULT_SESSION;
+        sessions = new ArrayList<>();
     }
 
     /**
@@ -126,7 +121,7 @@ public class StudentBuilder {
     /**
      * Adds a {@code Session} to the {@code sessions} of the {@code Student}.
      */
-    public StudentBuilder withSession(Session session) {
+    public StudentBuilder addSession(Session session) {
         requireAllNonNull(session);
         this.sessions.add(session);
         return this;

--- a/src/test/java/seedu/address/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/address/testutil/TypicalStudents.java
@@ -31,7 +31,7 @@ public class TypicalStudents {
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withStudyLevel("Sec 2").withGuardianPhone("82813844")
             .withRelationship("Mother")
-                        .withSession(
+                        .addSession(
                                 new SessionBuilder().withSessionDate("2020-01-01", "12:00").build()
                         )
             .build();
@@ -39,7 +39,7 @@ public class TypicalStudents {
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withStudyLevel("Primary 2").withGuardianPhone("81902144").withRelationship("Father")
-                        .withSession(
+                        .addSession(
                                 new SessionBuilder().withSessionDate("2020-01-02", "12:00").build()
                         )
             .build();

--- a/src/test/java/seedu/address/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/address/testutil/TypicalStudents.java
@@ -31,17 +31,17 @@ public class TypicalStudents {
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withStudyLevel("Sec 2").withGuardianPhone("82813844")
             .withRelationship("Mother")
-                        .addSession(
-                                new SessionBuilder().withSessionDate("2020-01-01", "12:00").build()
-                        )
+            .addSession(
+                    new SessionBuilder().withSessionDate("2020-01-01", "12:00").build()
+            )
             .build();
     public static final Student BENSON = new StudentBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withStudyLevel("Primary 2").withGuardianPhone("81902144").withRelationship("Father")
-                        .addSession(
-                                new SessionBuilder().withSessionDate("2020-01-02", "12:00").build()
-                        )
+            .addSession(
+                    new SessionBuilder().withSessionDate("2020-01-02", "12:00").build()
+            )
             .build();
     public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street")


### PR DESCRIPTION
Resolve #109 - Student/SessionBuilder bug

1. Removed unintended static `DEFAULT_SESSION`, replaced with new ArrayList for each new `StudentBuilder`
2. `withSession` renamed to `addSession`. To add a **list of sessions** into `StudentBuilder`, use `withListOfSessions` (to add on to current list), or `withNewListOfSessions` (for a clean slate of session list). These two methods have been added previously.
3. `EditStudentDescriptorBuilder` has been edited to include sessions as well (future-proofing).