### PR TITLE
Update equals method for UniqueStudentList

### DIFF
--- a/src/main/java/seedu/address/model/student/UniqueStudentList.java
+++ b/src/main/java/seedu/address/model/student/UniqueStudentList.java
@@ -223,6 +223,10 @@ public class UniqueStudentList implements Iterable<Student> {
                         && allSessionEquals(otherUniqueStudentList.internalList));
     }
 
+    /**
+     * Checks if all sessions of each student in {@code internalList} are equal to all sessions
+     * of each student in {@code studentList}.
+     */
     private boolean allSessionEquals(ObservableList<Student> studentList) {
         for (int i = 0; i < internalList.size(); i++) {
             Student currStudent = internalList.get(i);

--- a/src/main/java/seedu/address/model/student/UniqueStudentList.java
+++ b/src/main/java/seedu/address/model/student/UniqueStudentList.java
@@ -216,9 +216,28 @@ public class UniqueStudentList implements Iterable<Student> {
 
     @Override
     public boolean equals(Object other) {
+        UniqueStudentList otherUniqueStudentList = (UniqueStudentList) other;
         return other == this // short circuit if same object
                 || (other instanceof UniqueStudentList // instanceof handles nulls
-                        && internalList.equals(((UniqueStudentList) other).internalList));
+                        && internalList.equals(otherUniqueStudentList.internalList)
+                        && allSessionEquals(otherUniqueStudentList.internalList));
+    }
+
+    private boolean allSessionEquals(ObservableList<Student> studentList) {
+        for (int i = 0; i < internalList.size(); i++) {
+            Student currStudent = internalList.get(i);
+            Student otherStudent = studentList.get(i);
+            List<Session> currSessionList = currStudent.getListOfSessions();
+            List<Session> otherSessionList = otherStudent.getListOfSessions();
+            for (int j = 0; j < currSessionList.size(); j++) {
+                Session currSession = currSessionList.get(j);
+                Session otherSession = otherSessionList.get(j);
+                if (!currSession.equals(otherSession)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/UniqueStudentList.java
+++ b/src/main/java/seedu/address/model/student/UniqueStudentList.java
@@ -216,11 +216,10 @@ public class UniqueStudentList implements Iterable<Student> {
 
     @Override
     public boolean equals(Object other) {
-        UniqueStudentList otherUniqueStudentList = (UniqueStudentList) other;
         return other == this // short circuit if same object
                 || (other instanceof UniqueStudentList // instanceof handles nulls
-                        && internalList.equals(otherUniqueStudentList.internalList)
-                        && allSessionEquals(otherUniqueStudentList.internalList));
+                        && internalList.equals(((UniqueStudentList) other).internalList)
+                        && allSessionEquals(((UniqueStudentList) other).internalList));
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/typicalStudentsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalStudentsAddressBook.json
@@ -11,12 +11,29 @@
     "sessions": [
       {
         "type" : "JsonAdaptedSession",
-        "sessionDate": "2020-01-01T12:00",
+        "sessionDate": "2021-02-05T12:00",
         "duration": "100",
         "subject": "COMPUTING",
-        "fee": "40.0"
-      }
-    ]
+        "fee": "39.40"
+      }, {
+        "type" : "JsonAdaptedSession",
+        "sessionDate": "2021-02-01T12:00",
+        "duration": "100",
+        "subject": "COMPUTING",
+        "fee": "81.50"
+      }, {
+        "type" : "JsonAdaptedSession",
+        "sessionDate": "2021-03-01T12:00",
+        "duration": "100",
+        "subject": "COMPUTING",
+        "fee": "29.31"
+      }, {
+        "type" : "JsonAdaptedSession",
+        "sessionDate": "2020-02-01T12:00",
+        "duration": "100",
+        "subject": "COMPUTING",
+        "fee": "50.28"
+      } ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
@@ -44,11 +61,13 @@
     "relationship" : "Mother",
     "sessions": [
       {
-        "type" : "JsonAdaptedSession",
-        "sessionDate": "2020-01-03T12:00",
+        "type" : "JsonAdaptedRecurringSession",
+        "sessionDate": "2021-01-01T00:00",
         "duration": "100",
         "subject": "COMPUTING",
-        "fee": "40.0"
+        "fee": "40.0",
+        "interval" : "7",
+        "lastSessionDate" : "2021-01-15T00:00"
       }
     ]
   }, {
@@ -59,15 +78,7 @@
     "studyLevel" : "Junior College 2",
     "guardianPhone" : "97213021",
     "relationship" : "Father",
-    "sessions": [
-      {
-        "type" : "JsonAdaptedSession",
-        "sessionDate": "2020-01-04T12:00",
-        "duration": "100",
-        "subject": "COMPUTING",
-        "fee": "40.0"
-      }
-    ]
+    "sessions" : [ ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "94822242",
@@ -76,15 +87,7 @@
     "studyLevel" : "Primary 2",
     "guardianPhone" : "92134012",
     "relationship" : "Mother",
-    "sessions": [
-      {
-        "type" : "JsonAdaptedSession",
-        "sessionDate": "2020-01-05T12:00",
-        "duration": "100",
-        "subject": "COMPUTING",
-        "fee": "40.0"
-      }
-    ]
+    "sessions" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "94824272",
@@ -93,15 +96,7 @@
     "studyLevel" : "Sec 2",
     "guardianPhone" : "99021234",
     "relationship" : "Mother",
-    "sessions": [
-      {
-        "type" : "JsonAdaptedSession",
-        "sessionDate": "2020-01-06T12:00",
-        "duration": "100",
-        "subject": "COMPUTING",
-        "fee": "40.0"
-      }
-    ]
+    "sessions" : [ ]
   }, {
     "name" : "George Best",
     "phone" : "94824422",
@@ -110,14 +105,6 @@
     "studyLevel" : "Sec 3",
     "guardianPhone" : "87620000",
     "relationship" : "Father",
-    "sessions": [
-      {
-        "type" : "JsonAdaptedSession",
-        "sessionDate": "2020-01-07T12:00",
-        "duration": "100",
-        "subject": "COMPUTING",
-        "fee": "40.0"
-      }
-    ]
+    "sessions" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteSessionCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SESSION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
@@ -9,11 +10,16 @@ import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.session.Session;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
+import seedu.address.testutil.SessionBuilder;
+import seedu.address.testutil.StudentBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -24,25 +30,50 @@ class DeleteSessionCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-    /*
+
     @Test
-    public void execute_validNameValidIndex_success() {
-        Student studentWithSession = model.getAddressBook().getStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+    public void execute_validNameValidIndex_success() throws CommandException {
+        AddressBook deletionAddressBook = new AddressBook();
+        deletionAddressBook.addStudent(new StudentBuilder().withName("Alice Pauline")
+                .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+                .withPhone("94351253").withStudyLevel("Sec 2").withGuardianPhone("82813844")
+                .withRelationship("Mother")
+                .addSessions(
+                        new SessionBuilder().withSessionDate("2021-02-05", "12:00").withFee("39.40").build(),
+                        new SessionBuilder().withSessionDate("2021-02-01", "12:00").withFee("81.50").build(),
+                        new SessionBuilder().withSessionDate("2021-03-01", "12:00").withFee("29.31").build(),
+                        new SessionBuilder().withSessionDate("2020-02-01", "12:00").withFee("50.28").build()
+                )
+                .build());
+        Model deletionModel = new ModelManager(deletionAddressBook, new UserPrefs());
+
+        Student studentWithSession = deletionModel.getAddressBook().getStudentList()
+                .get(INDEX_FIRST_STUDENT.getZeroBased());
         Session sessionToDelete = studentWithSession.getListOfSessions().get(INDEX_FIRST_SESSION.getZeroBased());
         DeleteSessionCommand deleteSessionCommand =
                 new DeleteSessionCommand(studentWithSession.getName(), INDEX_FIRST_SESSION);
 
-        String expectedMessage = String.format(DeleteSessionCommand.MESSAGE_DELETE_SESSION_SUCCESS, sessionToDelete);
+        String expectedMessage = String.format(DeleteSessionCommand.MESSAGE_DELETE_SESSION_SUCCESS,
+                sessionToDelete.toString());
 
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        AddressBook expectedAddressBook = new AddressBook();
+        expectedAddressBook.addStudent(new StudentBuilder().withName("Alice Pauline")
+                .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+                .withPhone("94351253").withStudyLevel("Sec 2").withGuardianPhone("82813844")
+                .withRelationship("Mother")
+                .addSessions(
+                        new SessionBuilder().withSessionDate("2021-02-05", "12:00").withFee("39.40").build(),
+                        new SessionBuilder().withSessionDate("2021-02-01", "12:00").withFee("81.50").build(),
+                        new SessionBuilder().withSessionDate("2021-03-01", "12:00").withFee("29.31").build(),
+                        new SessionBuilder().withSessionDate("2020-02-01", "12:00").withFee("50.28").build()
+                )
+                .build());
+        ModelManager expectedModel = new ModelManager(expectedAddressBook, new UserPrefs());
         expectedModel.deleteSession(studentWithSession.getName(), INDEX_FIRST_SESSION);
 
-
-            CommandResult actual = deleteSessionCommand.execute(model);
-            assertCommandSuccess(deleteSessionCommand, model, new CommandResult(expectedMessage), expectedModel);
-        assertCommandSuccess(deleteSessionCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteSessionCommand, deletionModel, expectedMessage, expectedModel);
     }
-     */
+
 
 
     @Test


### PR DESCRIPTION
1. Update equals method for UniqueStudentList so that when testing for equality of model and addressbook also checks for the equality between sessions.
2. Update the typicalStudentAddressBook.json file to match that of TypicalStudents.
3. In DeleteSessionCommandTest success case, note that i avoided using getTypicalStudents() for the model and instead manually added them because I did not want the same student object in both models.

![image](https://user-images.githubusercontent.com/39006568/113483157-98a72300-94d4-11eb-9dc5-9de0b5dbab33.png)
![image](https://user-images.githubusercontent.com/39006568/113483163-a066c780-94d4-11eb-9a29-2d5c16bcaed7.png)
Now the student and sessions are unique. whereas previously when calling getTypicalAddressBook() all students and sessions are  the same objects.