### PR TITLE
Fix result display click copies bug

### DIFF
--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -4,8 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
-import javafx.scene.input.Clipboard;
-import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.Region;
 
 /**
@@ -27,17 +25,6 @@ public class ResultDisplay extends UiPart<Region> {
         this.feedbackToUser = feedbackToUser;
         requireNonNull(feedbackToUser);
         resultDisplay.setText(feedbackToUser);
-    }
-
-    /**
-     * Copies the URL to the user guide to the clipboard.
-     */
-    @FXML
-    private void copyUrl() {
-        final Clipboard clipboard = Clipboard.getSystemClipboard();
-        final ClipboardContent url = new ClipboardContent();
-        url.putString(feedbackToUser);
-        clipboard.setContent(url);
     }
 
 }

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,5 +5,5 @@
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true" onMouseClicked="#copyUrl"/>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true"/>
 </StackPane>


### PR DESCRIPTION
Resolve #251 - Clicking on result display will copy to clipboard

Was intended as a feature for `emails`, but there wasn't a way to isolate it to this command only. Suggest to scrap this whole feature entirely.