### PR TITLE
Attempt to resolve bug that list number is not consecutive

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -333,7 +333,9 @@ Example 2:
 
 ![find_student_example](images/enhao/find_student%20-%20edited.png)
 
-3. The student and session list will be filtered and only contains students and sessions of students whose name contains the keywords specified.
+<ol start="3">
+    <li>The student and session list will be filtered and only contains students and sessions of students whose name contains the keywords specified.</li>
+</ol>
 
 ![find_student_result_example](images/enhao/find_student_result%20-%20edited.png)
 
@@ -351,8 +353,9 @@ Example:
 
 ![edit_student_example](images/enhao/edit_student%20-%20edited.png)
 
-3. The edited student information will be reflected in the student list.
-
+<ol start="3">
+    <li>The edited student information will be reflected in the student list.</li>
+</ol>
 ![edit_student_result_example](images/enhao/edit_student_result%20-%20edited.png)
 
 <div markdown="span" class="alert alert-primary">:bulb: Tip:
@@ -375,7 +378,9 @@ Example:
 
 ![delete_student_example](images/enhao/delete_student%20-%20edited.png)
 
-3. The 2nd student in the list (**Bernice Yu**) and her associated sessions will be deleted.
+<ol start="3">
+    <li>The 2nd student in the list (**Bernice Yu**) and her associated sessions will be deleted.</li>
+</ol>
 
 ![delete_student_result_example](images/enhao/delete_student_result%20-%20edited.png)
 
@@ -400,11 +405,15 @@ Example:
 
 ![emails_example](images/enhao/email%20-%20edited.png)
 
-3. The concatenated text of all the students' emails will be displayed.
+<ol start="3">
+    <li>The concatenated text of all the students' emails will be displayed.</li>
+</ol>
 
 ![emails_result_example](images/enhao/email_result%20-%20edited.png)
 
-4. The user can copy the values in the result display box to the "To" field of any email client that they have (E.g. Gmail).
+<ol start="4">
+    <li>The user can copy the values in the result display box to the "To" field of any email client that they have (E.g. Gmail).</li>
+</ol>
 
 ![emails_client_example](images/enhao/email_client-edited.png)
 
@@ -522,7 +531,9 @@ Example:
 
 ![fee_example](images/enhao/fee%20-%20Edited.PNG)
 
-3. The result display box displays John Doe's monthly fee for March 2021.
+<ol start="3">
+    <li>The result display box displays John Doe's monthly fee for March 2021.</li>
+</ol>
 
 ![fee_result_example](images/enhao/fee_result%20-%20Edited.PNG)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -291,7 +291,7 @@ Example:
 ![add_student_example](images/enhao/add_student%20-%20edited.png)
 
 <ol start="3">
-    <li>Scrolling down to the end of the student list, you will see that **John Doe** has been added to TutorBuddy.</li>
+    <li>Scrolling down to the end of the student list, you will see that <b>John Doe</b> has been added to TutorBuddy.</li>
 </ol>
 
 ![add_student_result_example](images/enhao/add_student_result%20-%20edited.png)
@@ -356,6 +356,7 @@ Example:
 <ol start="3">
     <li>The edited student information will be reflected in the student list.</li>
 </ol>
+
 ![edit_student_result_example](images/enhao/edit_student_result%20-%20edited.png)
 
 <div markdown="span" class="alert alert-primary">:bulb: Tip:
@@ -379,7 +380,7 @@ Example:
 ![delete_student_example](images/enhao/delete_student%20-%20edited.png)
 
 <ol start="3">
-    <li>The 2nd student in the list (**Bernice Yu**) and her associated sessions will be deleted.</li>
+    <li>The 2nd student in the list (<b>Bernice Yu</b>) and her associated sessions will be deleted.</li>
 </ol>
 
 ![delete_student_result_example](images/enhao/delete_student_result%20-%20edited.png)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -251,7 +251,7 @@ Clears all student and session data.
 
 <div markdown="span" class="alert alert-primary">:bulb: Tip:
 TutorBuddy provides sample data to allow you to try out the application easily. <br>
-Run the <code>clear</code> command to start working with TutorBuddy in a clean slate.
+Run the <code>clear</code> command <b>after</b> you have explored the application and wants to start working with TutorBuddy in a clean slate.
 </div>
 
 Format: `clear`


### PR DESCRIPTION
Currently, there is a bug in the UG where the numbering is not consecutive after it is converted to HTML. This is due to the way it converts to an ordered list.

![image](https://user-images.githubusercontent.com/24240408/114330125-98adbf80-9b73-11eb-8bf6-ea3eb78ae28a.png)

Hence, to overcome this, I manually set the ordered list and start value using HTML. Tried it on add_student already and it works

![image](https://user-images.githubusercontent.com/24240408/114330218-cd217b80-9b73-11eb-8d29-692e2ab9fd77.png)

@JonahhGohh and @yungweezy can probably do the same, I think your will have the same issue as well ah. (Note that those md format such as **Bold** needs to be changed to its HTML counterpart <b>Bold</b> instead for it to work)